### PR TITLE
Keep babashka compatibility

### DIFF
--- a/src/clj_commons/ansi.clj
+++ b/src/clj_commons/ansi.clj
@@ -4,12 +4,11 @@
 
   Reference: [ANSI Escape Codes @ Wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR)."
   (:require [clojure.string :as str]
-            [clj-commons.pretty-impl :refer [csi padding]])
-  (:import (clojure.lang Namespace)))
+            [clj-commons.pretty-impl :refer [csi padding]]))
 
 (defn- is-ns-loaded?
   [sym]
-  (some? (Namespace/find sym)))
+  (some? (find-ns sym)))
 
 (defn- to-boolean
   [s]
@@ -311,4 +310,3 @@
     (when dirty?
       (.append buffer reset-font))
     (.toString buffer)))
-


### PR DESCRIPTION
This change proposes to replace `Namespace/find` with `clojure.core/find-ns`.

Attempting to run pretty 2.0.1 in babashka yields an error:

```
   (Namespace/find sym)
    ^--- No matching method find found taking 1 args
```

This is introduced in a recent change (https://github.com/clj-commons/pretty/pull/95), the previous version 2.0 works fine. This is because `Namespace/find` is not compiled (probably considered an implementation detail).
But `clojure.core/find-ns` is included and is equivalent

https://github.com/clojure/clojure/blob/38bafca9e76cd6625d8dce5fb6d16b87845c8b9d/src/clj/clojure/core.clj#L4126-L4130

