### PR TITLE
Realize all bean properties so we don't crash later

### DIFF
--- a/src/clj_commons/format/exceptions.clj
+++ b/src/clj_commons/format/exceptions.clj
@@ -426,7 +426,7 @@
   [^Throwable exception options]
   (if (instance? ExceptionInfo exception)
     (wrap-exception exception (ex-data exception) options)
-    (let [properties          (try (bean exception)
+    (let [properties          (try (into {} (bean exception))
                                    (catch Throwable _ nil))
           ;; Ignore basic properties of Throwable, any nil properties, and any properties
           ;; that are themselves Throwables


### PR DESCRIPTION
Sample exception to try to print (on Java 16+):
```
(clj-http.client/get "https://untrusted-root.badssl.com/")
```

This is a follow-up to the fix in #78 - that try/catch was not enough.