### PR TITLE
Fix tables in docstrings

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -44,6 +44,13 @@ jobs:
       - name: Run tests (Clojure 1.10)
         run: clojure -X:1.10:test
 
+      - uses: actions/checkout@v1
+      - name: Build JAR for cljdoc analysis
+        run: clojure -T:build jar
+
+      - name: CljDoc Check
+        uses: cljdoc/cljdoc-check-action@v1
+
 
 
 

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -15,21 +15,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v4.2.1
         with:
           java-version: '11'
           distribution: 'corretto'
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@11.0
+        uses: DeLaGuardo/setup-clojure@12.5
         with:
-          cli: 1.11.1.1257
+          cli: 1.11.2.1446
 
       - name: Cache clojure dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -49,7 +49,7 @@ jobs:
         run: clojure -T:build jar
 
       - name: CljDoc Check
-        uses: cljdoc/cljdoc-check-action@v1
+        uses: cljdoc/cljdoc-check-action@v0.0.3
 
 
 

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -43,14 +43,3 @@ jobs:
 
       - name: Run tests (Clojure 1.10)
         run: clojure -X:1.10:test
-
-      - uses: actions/checkout@v1
-      - name: Build JAR for cljdoc analysis
-        run: clojure -T:build jar
-
-      - name: CljDoc Check
-        uses: cljdoc/cljdoc-check-action@v0.0.3
-
-
-
-

--- a/deps.edn
+++ b/deps.edn
@@ -1,12 +1,12 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}}
 
  :aliases
  {:test
   ;; clj -X:test
   {:extra-paths ["test"]
    :extra-deps {criterium/criterium {:mvn/version "0.4.6"}
-                org.clojure/core.async {:mvn/version "1.6.673"}
+                org.clojure/core.async {:mvn/version "1.6.681"}
                 io.github.cognitect-labs/test-runner {:git/tag "v0.5.1"
                                                       :git/sha "dfb30dd"}}
    :jvm-opts ["-Dclj-commons.ansi.enabled=true"]
@@ -15,11 +15,11 @@
   ;; clj -T:build <command>
   :build
   {:deps {io.github.hlship/build-tools
-          {:git/tag "0.10.1" :git/sha "7ecff5b"}}
+          {:git/tag "0.10.2" :git/sha "3c446e4"}}
    :ns-default build}
 
   :1.10
-  {:override-deps {org.clojure/clojure {:mvn/version "1.10.0"}}}
+  {:override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}}
 
   ;; clj -M:test:demo
   :demo
@@ -29,7 +29,7 @@
   {:jvm-opts ["-Dclj-commons.ansi.enabled=false"]}
 
   :nrepl
-  {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}}
+  {:extra-deps {nrepl/nrepl {:mvn/version "1.1.1"}}
    :main-opts ["-m" "nrepl.cmdline" ]}
 
   :repl

--- a/src/clj_commons/ansi.clj
+++ b/src/clj_commons/ansi.clj
@@ -285,14 +285,14 @@
 
   The terms:
 
-  | Characteristic   | Values                                 |
-  | --               | --                                     |
-  | foreground color | `red` or `bright-red` (for each color) |
-  | background color |  same as foreground color              |
-  | boldness         | `bold`, `faint`, or `plain`            |
-  | italics          | `italic` or `roman`                    |
-  | inverse          | `inverse` or `normal`                  |
-  | underline        | `underlined` or `not-underlined`       |
+  Characteristic   | Values
+  ---              | ---
+  foreground color | `red` or `bright-red` (for each color)
+  background color |  same as foreground color
+  boldness         | `bold`, `faint`, or `plain`
+  italics          | `italic` or `roman`
+  inverse          | `inverse` or `normal`
+  underline        | `underlined` or `not-underlined`
 
   e.g.
 

--- a/src/clj_commons/ansi.clj
+++ b/src/clj_commons/ansi.clj
@@ -286,7 +286,7 @@
   The terms:
 
   Characteristic   | Values
-  ---              | ---
+  ---              |---
   foreground color | `red` or `bright-red` (for each color)
   background color |  same as foreground color
   boldness         | `bold`, `faint`, or `plain`
@@ -324,7 +324,7 @@
   The span's font declaration may also be a map with the following keys:
 
   Key    | Type    | Description
-  --     |--       |--
+  ---    |---      |---
   :font  | keyword | The font declaration
   :width | number  | The visual width of the span
   :pad   | keyword | Where to pad the span, :left, :right, or :both; default is :left

--- a/src/clj_commons/format/binary.clj
+++ b/src/clj_commons/format/binary.clj
@@ -136,8 +136,9 @@
 
   The full version specifies the [[BinaryData]] to write, and options:
 
+
   Key         | Type    | Description
-  --          |--       |--
+  ---         |---      |---
   :ascii      | boolean | If true, enable ASCII mode
   :line-bytes | number  | Bytes printed per line
 

--- a/src/clj_commons/format/exceptions.clj
+++ b/src/clj_commons/format/exceptions.clj
@@ -310,7 +310,7 @@
   "Extracts the stack trace for an exception and returns a seq of expanded stack frame maps:
 
   Key           | Type          | Description
-  --            |--             |--
+  ---           |---            |---
   :file         | String        | Source file name
   :line         | Integer       | Line number as integer, or nil
   :class        | String        | Fully qualified Java class name
@@ -429,12 +429,12 @@
 
   Each exception map contains:
 
-  | Key          | Type   | Description
-  |--            |--      |--
-  | :class-name  | String | Name of Java class for the exception
-  | :message     | String | Value of the exception's message property (possibly nil)
-  | :properties  | String | Map of properties to (optionally) present in the exception report
-  | :stack-trace | Vector | Stack trace element maps (as per [[expand-stack-trace]]), or nil; only present in the root exception
+  Key          | Type   | Description
+  ---          |---     |---
+  :class-name  | String | Name of Java class for the exception
+  :message     | String | Value of the exception's message property (possibly nil)
+  :properties  | String | Map of properties to (optionally) present in the exception report
+  :stack-trace | Vector | Stack trace element maps (as per [[expand-stack-trace]]), or nil; only present in the root exception
 
   The :properties map does not include any properties that are assignable to type Throwable.
 
@@ -618,7 +618,7 @@
   The options map may have the following keys:
 
   Key          | Description
-  --           |--
+  ---          |---
   :filter      | The stack frame filter, which defaults to [[*default-stack-frame-filter*]]
   :properties  | If true (the default) then properties of exceptions will be output
   :frame-limit | If non-nil, the number of stack frames to keep when outputting the stack trace of the deepest exception
@@ -639,7 +639,7 @@
   in the stack trace, and must return one of the following values:
 
   Value      | Description
-  --         |--
+  ---        |---
   :show      | The normal state; display the stack frame
   :hide      | Prevents the frame from being displayed, as if it never existed
   :omit      | Replaces the frame with a \"...\" placeholder

--- a/src/clj_commons/format/table.clj
+++ b/src/clj_commons/format/table.clj
@@ -102,7 +102,7 @@
   Alternately, a column can be a map:
 
   Key        | Type                 | Description
-  --         |--                    |--
+  ---        |---                   |---
   :key       | keyword/function     | Passed the row data and returns the value for the column (required)
   :title     | String               | The title for the column
   :title-pad | :left, :right, :both | How to pad the title column; default is :both to center the title
@@ -129,7 +129,7 @@
   opts can be a seq of columns, or it can be a map of options:
 
   Key                | Type           | Description
-  --                 |--              |--
+  ---                |---             |---
   :columns           | seq of columns | Describes the columns to print
   :style             | map            | Overrides the default styling of the table
   :default-decorator | function       | Used when a column doesn't define it own decorator


### PR DESCRIPTION
It's really important to use _at least three_ dashes.  Also, it turns out codox supports these tables, in this format, as well.