### PR TITLE
Add shims to allow org.clj-commons/pretty to be used in place of io.aviso/pretty in the majority of cases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 - The function `clojure.core/apply` is now omitted (in formatted stack traces)
 - Properties inside exceptions are now pretty-printed a default depth of 2; previously, the depth was unlimited
 
+Other changes:
+
+A limited number of vars and functions defined by the io.aviso/pretty artifact have been added, allowing org.clj-commons/pretty to swap in for io.aviso/pretty in many cases.
+
 ## 2.4.0 - 24 Mar 202
 
 *BREAKING CHANGES*

--- a/src/io/aviso/exception.clj
+++ b/src/io/aviso/exception.clj
@@ -1,0 +1,33 @@
+(ns io.aviso.exception
+  "A shim in org.clj-commons/pretty to emulate a few key functions from io.aviso/pretty.
+
+  This namespace may be deleted in a future release."
+  {:added "2.5.0"
+   :deprecated "2.5.0"}
+  (:require [clj-commons.format.exceptions :as e]))
+
+(defn demangle
+  [^String s]
+  (e/demangle s))
+
+(defn format-exception
+  ([exception]
+   (e/format-exception exception))
+  ([exception options]
+   (e/format-exception exception options)))
+
+(defn write-exception
+  ([exception]
+   (e/print-exception exception))
+  ([exception options]
+   (e/print-exception exception options)))
+
+(def ^:dynamic *default-frame-rules*
+  "This is provided only to prevent source compilation failures; changing this value does not affect
+  how the clj-commons.format.exceptions namespace operates."
+  [])
+
+(def ^:dynamic *fonts*
+  "This is provided only to prevent source compilation failures; changing this value does not affect
+  how the clj-commons.format.exceptions namespace operates."
+  {})

--- a/src/io/aviso/repl.clj
+++ b/src/io/aviso/repl.clj
@@ -1,0 +1,15 @@
+(ns io.aviso.repl
+  "A shim in org.clj-commons/pretty to emulate a few key functions from io.aviso/pretty.
+
+  This namespace may be deleted in a future release."
+  {:added "2.5.0"
+   :deprecated "2.5.0"}
+  (:require [clj-commons.pretty.repl :as repl]))
+
+(defn install-pretty-exceptions
+  []
+  (repl/install-pretty-exceptions))
+
+(defn uncaught-exception-handler
+  []
+  (repl/uncaught-exception-handler))


### PR DESCRIPTION
Fixes #111 