### PR TITLE
Make visible fn's to extract/filter/format stack frames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,14 @@
 ## 3.0.0 - UNRELEASED
  
-*BREAKING CHANGES*:
+**BREAKING CHANGES**:
 
-Moved the io.aviso compatibility layer to new library
+Moved the io.aviso/pretty compatibility layer to new library
 [org.clj-commons/pretty-aviso-bridge](https://github.com/clj-commons/pretty-aviso-bridge).
 
 Other changes:
-- Added a cache to speed up analyzing the Java exception stack.
+- `clj-commons.format.exceptions`
+  - Added a cache to speed up transforming Java StackTraceElements
+  - Added new functions to make it easier to extract, filter, and format a stack trace outside of formatting an entire exception
 
 ## 2.6.0 - 25 Apr 2024
 

--- a/test/demo.clj
+++ b/test/demo.clj
@@ -7,6 +7,7 @@
     [clojure.java.io :as io]
     [clojure.repl :refer [pst]]
     [criterium.core :as c]
+    playground
     [clojure.test :refer [report deftest is]])
   (:import
     (java.nio.file Files)
@@ -161,4 +162,6 @@
   (let [e (make-ex-info)]
     (c/bench (doseq [x (e/analyze-exception e nil)]
                (-> x :stack-trace doall))))
+
+  (playground/caller)
   )

--- a/test/playground.clj
+++ b/test/playground.clj
@@ -1,0 +1,40 @@
+(ns playground
+  (:require [clj-commons.ansi :as ansi]
+            [clj-commons.format.exceptions :as e]))
+
+(defn deprecation-warning
+  [id]
+  (let [names (->> (Thread/currentThread)
+                   .getStackTrace
+                   (drop 1)                                 ; call to .getStackTrace()
+                   (e/transform-stack-trace)
+                   (e/filter-stack-trace-maps)
+                   (drop-while #(= "playground/deprecation-warning" (:name %)))
+                   (remove :omitted)
+                   (map e/format-stack-frame)
+                   (map :name)
+                   reverse
+                   (interpose " -> "))]
+    (ansi/perr [:yellow
+                [:bold "WARNING:"]
+                " " id " is deprecated ...\n"]
+               "Call trace: "
+               names)))
+
+(defmacro deprecated
+  [id & body]
+  `(do
+     (deprecation-warning ~id)
+     ~@body))
+
+(defn my-deprecated-fn
+  []
+  (deprecated `my-deprecated-fn))
+
+(defn caller
+  []
+  (my-deprecated-fn))
+
+(comment
+  (caller)
+  )


### PR DESCRIPTION
This makes it possible to extract, filter, and transform (for output) an arbitrary stack trace, such as from Thread/getStackTrace(), entirely separately from formatting an exception.