### PR TITLE
Abbreviated repeated names in a Clojure function name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,18 @@
+## 3.1.0 - UNRELEASED
+
+In a Clojure stack frame, repeated elements may be abbreviated; for example,
+what was output in 3.0.0 as
+`integration.diplomat.components.github-api-test/fn/fn/fn/fn/fn/fn/fn/fn/fn/fn/fn/fn/fn/fn`
+will be output in 3.1.0 as `integration.diplomat.components.github-api-test/fn{x14}`
+(this is an actual test case!)
+These crazily nested functions occur when using macro-intensive libraries such as
+[nubank/state-flow](https://github.com/nubank/state-flow) and [funcool/cats](https://github.com/funcool/cats).
+
 ## 3.0.0 - 7 Jun 2024
  
 **BREAKING CHANGES**:
 
-Moved the io.aviso/pretty compatibility layer to new library
+Moved the io.aviso/pretty compatibility layer (introduced in 2.5.0) to new library
 [org.clj-commons/pretty-aviso-bridge](https://github.com/clj-commons/pretty-aviso-bridge).
 
 Other changes:
@@ -30,7 +40,7 @@ Minor bug fixes.
 *BREAKING CHANGES*
 
 - The function `clojure.core/apply` is now omitted (in formatted stack traces)
-- Properties inside exceptions are now pretty-printed  to a default depth of 2; previously, the depth was unlimited
+- Properties inside exceptions are now pretty-printed to a default depth of 2; previously, the depth was unlimited
 
 Other changes:
 

--- a/test/playground.clj
+++ b/test/playground.clj
@@ -35,6 +35,22 @@
   []
   (my-deprecated-fn))
 
+(defn deep
+  [x]
+  ((fn [x1]
+     ((fn [x2]
+        ((fn [x3]
+           ((fn inner [x4]
+              (/ x4 0)) x3))
+         x2))
+      x1))
+   x))
+
 (comment
   (caller)
+
+  (deep 10)
+
+  (clojure.repl/pst)
+
   )


### PR DESCRIPTION
After demangling strips off the numeric suffix from a Clojure function name, in cases where you have deeply nested anonymous functions (say, because you are using nubank/state-flow) you can with a long name of repeated `/fn/fn/fn..` values; this change reduces those repeats down to `/fn{x14}` (the actual count).