### PR TITLE
New namespace to produce pretty annotations on input lines

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -18,13 +18,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.5.0
         with:
           java-version: '11'
           distribution: 'corretto'
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@12.5
+        uses: DeLaGuardo/setup-clojure@13.0
         with:
           cli: 1.11.2.1446
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,23 @@
+## 3.3.0 -- UNRELEASED
+
+The new `clj-commons.pretty.annotations` namespace provides functions to help create pretty errors
+when parsing or interpretting text:
+
+```text
+SELECT DATE, AMT FROM PAYMENTS WHEN AMT > 10000
+             ▲▲▲               ▲▲▲▲
+             │                 │
+             │                 └╴ Unknown token
+             │
+             └╴ Invalid column name
+```
+
+Annotations are callouts that target a specific portion of a line; the `callouts` function can handle multiple
+annotations on a single line, with precise control over styling and layout.
+
+The new `clj-commons.pretty.spec` namespace provides type and function specs for the `clj-commons.ansi` and
+`clj-commons.pretty.annotations` namespaces.
+
 ## 3.2.0 - 20 Sep 2024
 
 Added `clj-commons.ansi/pout` to replace the `pcompose` function; they are identical, but the `pout` name makes more
@@ -44,7 +64,7 @@ Other changes:
 ## 2.6.0 - 25 Apr 2024
 
 - Font declaration in `compose` can now be a vector of individual terms, rather than a single keyword; e.g. `[:bold :red]` 
-  rather than `:bold.red`.
+  as an alternative to `:bold.red`. This can be useful when the font is computed, rather than a static literal.
 
 [Closed Issues](https://github.com/clj-commons/pretty/milestone/49?closed=1)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,20 @@ Here, the errors (called "annotations") are presented as callouts targetting spe
 
 The `callouts` function can handle multiple annotations on a single line, with precise control over styling and layout.
 
+The `annotate-lines` function builds on `callouts` to produce output of multiple lines from some source,
+interspersed with callouts:
+
+```text
+1: SELECT DATE, AMT
+          ▲▲▲              
+          │                              
+          └╴ Invalid column name
+2: FROM PAYMENTS WHEN AMT > 10000
+                 ▲▲▲▲                         
+                 │               
+                 └╴ Unknown token
+```                  
+
 The new `clj-commons.pretty.spec` namespace provides type and function specs for the `clj-commons.ansi` and
 `clj-commons.pretty.annotations` namespaces.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,9 @@ SELECT DATE, AMT FROM PAYMENTS WHEN AMT > 10000
              └╴ Invalid column name
 ```
 
-Annotations are callouts that target a specific portion of a line; the `callouts` function can handle multiple
-annotations on a single line, with precise control over styling and layout.
+Here, the errors (called "annotations") are presented as callouts targetting specific portions of the input line.
+
+The `callouts` function can handle multiple annotations on a single line, with precise control over styling and layout.
 
 The new `clj-commons.pretty.spec` namespace provides type and function specs for the `clj-commons.ansi` and
 `clj-commons.pretty.annotations` namespaces.
@@ -31,7 +32,7 @@ Added `clj-commons.format.exceptions/default-frame-rules` to supply defaults for
 which makes it much easier to override the default rules.
 
 Added function `clj-commons.format.exceptions/format-stack-trace-element` which can be used to convert a Java
-StackTraceElement into demangled, readable string, using the same logic as `format-exception.`
+StackTraceElement into a demangled, readable string, using the same logic as `format-exception.`
 
 [Closed Issues](https://github.com/clj-commons/pretty/milestone/52?closed=1)
 

--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,7 @@
   {:jvm-opts ["-Dclj-commons.ansi.enabled=false"]}
 
   :nrepl
-  {:extra-deps {nrepl/nrepl {:mvn/version "1.1.1"}}
+  {:extra-deps {nrepl/nrepl {:mvn/version "1.3.0"}}
    :main-opts ["-m" "nrepl.cmdline" ]}
 
   :repl

--- a/src/clj_commons/ansi.clj
+++ b/src/clj_commons/ansi.clj
@@ -2,6 +2,8 @@
   "Help with generating textual output that includes ANSI escape codes for formatting.
   The [[compose]] function is the best starting point.
 
+  Specs for types and functions are in the [[spec]] namespace.
+
   Reference: [ANSI Escape Codes @ Wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR)."
   (:require [clojure.string :as str]
             [clj-commons.pretty-impl :refer [csi padding]]))

--- a/src/clj_commons/pretty/annotations.clj
+++ b/src/clj_commons/pretty/annotations.clj
@@ -199,7 +199,7 @@
          ;; inc by one to account for the ':'
          line-number-width (inc (or (:line-number-width opts)
                                     (-> max-line-number str count)))
-         callout-indent (nchars (inc line-number-width) " ")]
+         callout-indent (repeat (nchars (inc line-number-width) " "))]
      (loop [[line-data & more-lines] lines
             line-number start-line
             result []]
@@ -215,7 +215,6 @@
                                        " "
                                        line))
                                callout-lines (into
-                                               (map list (repeat callout-indent)
-                                                    callout-lines)))]
+                                               (map list callout-indent callout-lines)))]
            (recur more-lines (inc line-number) result')))))))
 

--- a/src/clj_commons/pretty/annotations.clj
+++ b/src/clj_commons/pretty/annotations.clj
@@ -1,0 +1,141 @@
+(ns clj-commons.pretty.annotations
+  "Tools to annotate a line of source code, in the form of line and arrows connected to a message.
+
+      SELECT DATE, AMT FROM PAYMENTS WHEN AMT > 10000
+                   ▲▲▲               ▲▲▲▲
+                   │                 │
+                   │                 └╴ Unknown token
+                   │
+                   └╴ Invalid column name
+
+  This kind of output is common with various kinds of parsers or interpreters.
+
+  Specs for types and functions are in the [[spec]] namespace."
+  {:added "3.3.0"})
+
+(def default-style
+  "The default style used when generating annotations.
+
+  Key       | Default | Description
+  ---       |---      |---
+  :font     | :yellow | Font characteristics for annotations
+  :compact? | false   | If true, then omit the lines that are just vertical bars
+  :marker   | \"▲\"   | The marker character used to identify the offset/length of an annotation
+  :bar      | \"│\"   | Character used as the vertical bar
+  :nib      | \"└╴ \" | String used just before the annotation's message
+
+  Note: rendering of Unicode characters in HTML often uses incorrect fonts or adds unwanted
+  character spacing; the annotations look proper in console output."
+  {:font :yellow
+   :compact? false
+   :marker "▲"
+   :bar "│"
+   :nib "└╴ "})
+
+(defn- nchars
+  [n ch]
+  (apply str (repeat n ch)))
+
+(defn- markers
+  [style annotations]
+  (let [{:keys [font marker]} style]
+    (loop [output-offset 0
+           annotations annotations
+           result [font]]
+      (if-not annotations
+        result
+        (let [{:keys [offset length font]
+               :or {length 1}} (first annotations)
+              spaces-needed (- offset output-offset)
+              result' (conj result
+                            (nchars spaces-needed \space)
+                            [font (nchars length marker)])]
+          (recur (+ offset length)
+                 (next annotations)
+                 result'))))))
+
+(defn- bars
+  [style annotations]
+  (let [{:keys [font bar]} style]
+    (loop [output-offset 0
+           annotations annotations
+           result [font]]
+      (if-not annotations
+        result
+        (let [{:keys [offset font]} (first annotations)
+              spaces-needed (- offset output-offset)
+              result' (conj result
+                            (nchars spaces-needed \space)
+                            [font bar])]
+          (recur (+ offset 1)
+                 (next annotations)
+                 result'))))))
+
+(defn- bars+message
+  [style annotations]
+  (let [{:keys [font bar nib]} style]
+    (loop [output-offset 0
+           [annotation & more-annotations] annotations
+           result [font]]
+      (let [{:keys [offset font message]} annotation
+            spaces-needed (- offset output-offset)
+            last? (not (seq more-annotations))
+            result' (conj result
+                          (nchars spaces-needed \space)
+                          [font
+                           (if last?
+                             nib
+                             bar)
+                           (when last?
+                             message)])]
+        (if last?
+          result'
+          (recur (+ offset 1)
+                 more-annotations
+                 result'))))))
+
+(defn callouts
+  "Creates callouts (the marks, bars, and messages from the example) from annotations.
+
+  Each annotation is a map:
+
+  Key       | Description
+  ---       |---
+  :message  | Composed string of the message to present
+  :offset   | Integer position (from 0) to mark on the line
+  :length   | Number of characters in the marker (min 1, defaults to 1)
+  :font     | Override of the style's font; used for marker, bars, nib, and message
+
+
+  At least one annotation is required; they will be sorted into an appropriate order.
+  Annotation's ranges should not overlap.
+
+  The messages should be relatively short, and not contain any line breaks.
+
+  Returns a sequence of composed strings, one for each line of output.
+
+  The calling code is responsible for any output; even the line being annotated;
+  this might look something like:
+
+      (ansi/perr source-line)
+      (run! ansi/perr (annotations/annotate annotations))
+
+  "
+  ([annotations]
+   (callouts default-style annotations))
+  ([style annotations]
+   (let [expanded (->> annotations
+                       (sort-by :offset)
+                       ;; TODO: Check for overlaps
+                       vec)
+         {:keys [compact?]} style
+         marker-line (markers style expanded)]
+     (loop [annotations annotations
+            result [marker-line]]
+       (let [result' (-> result
+                         (cond-> (not compact?) (conj (bars style annotations)))
+                         (conj (bars+message style annotations)))
+             annotations' (butlast annotations)]
+         (if (seq annotations')
+           (recur annotations' result')
+           result'))))))

--- a/src/clj_commons/pretty/annotations.clj
+++ b/src/clj_commons/pretty/annotations.clj
@@ -1,5 +1,5 @@
 (ns clj-commons.pretty.annotations
-  "Tools to annotate a line of source code, in the form of line and arrows connected to a message.
+  "Tools to annotate a line of source code, in the form of callouts (lines and arrows) connected to a message.
 
       SELECT DATE, AMT FROM PAYMENTS WHEN AMT > 10000
                    ▲▲▲               ▲▲▲▲
@@ -14,14 +14,14 @@
   {:added "3.3.0"})
 
 (def default-style
-  "The default style used when generating annotations.
+  "The default style used when generating callouts.
 
   Key       | Default | Description
   ---       |---      |---
-  :font     | :yellow | Font characteristics for annotations
+  :font     | :yellow | Default font characteristics if not overrided by annotation
   :spacing  | :tall   | One of :tall, :compact, or :minimal
   :marker   | \"▲\"   | The marker character used to identify the offset/length of an annotation
-  :bar      | \"│\"   | Character used as the vertical bar
+  :bar      | \"│\"   | Character used as the vertical bar in the callout
   :nib      | \"└╴ \" | String used just before the annotation's message
 
   When :spacing is :minimal, only the lines with markers or error messages appear
@@ -35,6 +35,11 @@
    :marker "▲"
    :bar "│"
    :nib "└╴ "})
+
+(def ^:dynamic *default-style*
+  "The default style used when no style is provided; some applications may bind or
+   override this."
+  default-style)
 
 (defn- nchars
   [n ch]
@@ -124,9 +129,9 @@
       (ansi/perr source-line)
       (run! ansi/perr (annotations/annotate annotations))
 
-  "
+  Uses the style defined by [[*default-style*]] if no style is provided."
   ([annotations]
-   (callouts default-style annotations))
+   (callouts  *default-style* annotations))
   ([style annotations]
    ;; TODO: Check for overlaps
    (let [expanded (sort-by :offset annotations)
@@ -145,10 +150,3 @@
          (if (seq annotations')
            (recur annotations' false result')
            (remove nil? result')))))))
-
-(comment
-  (run! clj-commons.ansi/pout (callouts (assoc default-style :spacing :minimal)
-                                [{:offset 6 :message "Two"}
-                                 {:offset 3 :message "One"}]))
-  ;;
-  )

--- a/src/clj_commons/pretty/spec.clj
+++ b/src/clj_commons/pretty/spec.clj
@@ -1,0 +1,91 @@
+(ns clj-commons.pretty.spec
+  (:require [clojure.spec.alpha :as s]
+            [clj-commons.ansi :as ansi]
+            [clj-commons.pretty.annotations :as ann]))
+
+(s/def ::nonneg-integer (s/and integer? #(<= 0 %)))
+
+(s/def ::positive-integer (s/and integer? pos?))
+
+
+(s/def ::single-character (s/or
+                            :char char?
+                            :string (s/and string?
+                                           #(= 1 (count %)))))
+
+;; clj-commons.ansi:
+
+(s/def ::ansi/composed-string (s/or
+                                :string string?
+                                :nil nil?
+                                :span ::ansi/span
+                                :sequential ::ansi/composed-strings
+                                :other any?))
+
+(s/def ::ansi/span (s/and vector?
+                          (s/cat
+                            :font ::ansi/span-font
+                            :span-body (s/* ::ansi/composed-string))))
+
+(s/def ::ansi/span-font (s/or
+                          :nil nil?
+                          :font ::ansi/font
+                          :full ::ansi/span-font-full))
+
+(s/def ::ansi/font (s/or
+                     :simple keyword?
+                     :list (s/coll-of keyword? :kind vector?)))
+
+(s/def ::ansi/span-font-full (s/keys
+                               :opt-un [::ansi/font ::ansi/width ::ansi/pad]))
+
+(s/def ::ansi/width ::positive-integer)
+
+(s/def ::ansi/pad #{:left :right :both})
+
+(s/def ::ansi/composed-strings (s/and sequential?
+                                      (s/* ::ansi/composed-string)))
+
+(s/fdef ansi/compose
+        :args (s/* ::ansi/composed-string)
+        :ret string?)
+
+(s/fdef ansi/pout
+        :args (s/* ::ansi/composed-string)
+        :ret nil?)
+
+(s/fdef ansi/pcompose                                       ; old name of pout
+        :args (s/* ::ansi/composed-string)
+        :ret nil?)
+
+(s/fdef ansi/perr
+        :args (s/* ::ansi/composed-string)
+        :ret nil?)
+
+;; clj-commons.pretty.annotations
+
+(s/fdef ann/callouts
+        :args (s/cat
+                :style (s/? ::ann/style)
+                :annotations (s/+ ::ann/annotation))
+        :req (s/coll-of ::ansi/composed-string))
+
+(s/def ::ann/style (s/keys :req-un [::ansi/font
+                                    ::ann/compact?
+                                    ::ann/marker
+                                    ::ann/bar
+                                    ::ann/nib]))
+
+(s/def ::ann/compact? boolean?)
+(s/def ::ann/marker ::single-character)
+(s/def ::ann/bar ::single-character)
+(s/def ::ann/nib ::ansi/composed-string)
+
+(s/def ::ann/annotation (s/keys :req-un [::ann/message
+                                         ::ann/offset]
+                                :opt-un [::ann/length
+                                         ::ansi/font]))
+
+(s/def ::ann/message ::ansi/composed-string)
+(s/def ::ann/offset ::nonneg-integer)
+(s/def ::ann/length ::positive-integer)

--- a/src/clj_commons/pretty/spec.clj
+++ b/src/clj_commons/pretty/spec.clj
@@ -67,7 +67,7 @@
 (s/fdef ann/callouts
         :args (s/cat
                 :style (s/? ::ann/style)
-                :annotations (s/+ ::ann/annotation))
+                :annotations (s/coll-of ::ann/annotation))
         :req (s/coll-of ::ansi/composed-string))
 
 (s/def ::ann/style (s/keys :req-un [::ansi/font

--- a/src/clj_commons/pretty/spec.clj
+++ b/src/clj_commons/pretty/spec.clj
@@ -67,8 +67,8 @@
 (s/fdef ann/callouts
         :args (s/cat
                 :style (s/? ::ann/style)
-                :annotations (s/coll-of ::ann/annotation))
-        :req (s/coll-of ::ansi/composed-string))
+                :annotations ::ann/annotations)
+        :ret (s/coll-of ::ansi/composed-string))
 
 (s/def ::ann/style (s/keys :req-un [::ansi/font
                                     ::ann/spacing
@@ -81,6 +81,8 @@
 (s/def ::ann/bar ::single-character)
 (s/def ::ann/nib ::ansi/composed-string)
 
+(s/def ::ann/annotations (s/coll-of ::ann/annotation))
+
 (s/def ::ann/annotation (s/keys :req-un [::ann/message
                                          ::ann/offset]
                                 :opt-un [::ann/length
@@ -89,3 +91,23 @@
 (s/def ::ann/message ::ansi/composed-string)
 (s/def ::ann/offset ::nonneg-integer)
 (s/def ::ann/length ::positive-integer)
+
+(s/def ::ann/annotate-lines-opts (s/keys :opt-un [::ann/style
+                                                  ::ann/start-line
+                                                  ::ann/line-number-width]))
+
+(s/def ::ann/line-number-width ::positive-integer)
+(s/def ::ann/start-line ::positive-integer)
+
+(s/def ::ann/lines (s/coll-of ::ann/line-data))
+
+(s/def ::ann/line-data (s/keys :req-un [::ann/line]
+                               :opt-un [::ann/annotations]))
+
+(s/def ::ann/line ::ansi/composed-string)
+
+(s/fdef ann/annotate-lines
+        :args (s/cat
+                :opts (s/? (s/nilable ::ann/annotate-lines-opts))
+                :lines ::ann/lines)
+        :ret (s/coll-of ::ansi/composed-string))

--- a/src/clj_commons/pretty/spec.clj
+++ b/src/clj_commons/pretty/spec.clj
@@ -71,12 +71,12 @@
         :req (s/coll-of ::ansi/composed-string))
 
 (s/def ::ann/style (s/keys :req-un [::ansi/font
-                                    ::ann/compact?
+                                    ::ann/spacing
                                     ::ann/marker
                                     ::ann/bar
                                     ::ann/nib]))
 
-(s/def ::ann/compact? boolean?)
+(s/def ::ann/spacing #{:tall :compact :minimal})
 (s/def ::ann/marker ::single-character)
 (s/def ::ann/bar ::single-character)
 (s/def ::ann/nib ::ansi/composed-string)

--- a/test/clj_commons/ansi_test.clj
+++ b/test/clj_commons/ansi_test.clj
@@ -1,9 +1,12 @@
 (ns clj-commons.ansi-test
   (:require [clj-commons.ansi :as ansi]
+            [clj-commons.test-common :as tc]
             [clojure.string :as str]
-            [clojure.test :refer [deftest is are]]
+            [clojure.test :refer [deftest is are use-fixtures]]
             [clj-commons.ansi :refer [compose *color-enabled*]]
             [clj-commons.pretty-impl :refer [csi]]))
+
+(use-fixtures :once tc/spec-fixture)
 
 (deftest sanity-check
   (is (= true *color-enabled*)))

--- a/test/clj_commons/binary_test.clj
+++ b/test/clj_commons/binary_test.clj
@@ -2,9 +2,12 @@
   "Tests for the clj-commons.format.binary namespace."
   (:require [clj-commons.ansi :as ansi]
             [clj-commons.format.binary :as b]
+            [clj-commons.test-common :as tc]
             [clojure.string :as string]
-            [clojure.test :refer [deftest is are]])
+            [clojure.test :refer [deftest is are use-fixtures]])
   (:import (java.nio ByteBuffer)))
+
+(use-fixtures :once tc/spec-fixture)
 
 (defn- format-binary-plain
   [input]

--- a/test/clj_commons/exception_test.clj
+++ b/test/clj_commons/exception_test.clj
@@ -1,10 +1,13 @@
 (ns clj-commons.exception-test
-  (:use clojure.test)
-  (:require [clojure.string :as str]
+  (:require [clj-commons.test-common :as tc]
+            [clojure.test :refer [deftest is use-fixtures testing]]
+            [clojure.string :as str]
             [matcher-combinators.matchers :as m]
             [clj-commons.ansi :refer [*color-enabled*]]
             [clj-commons.pretty-impl :refer [csi]]
             [clj-commons.format.exceptions :as f :refer [*fonts* parse-exception format-exception]]))
+
+(use-fixtures :once tc/spec-fixture)
 
 (deftest write-exceptions
   (testing "exception properties printing"

--- a/test/clj_commons/pretty/annotations_test.clj
+++ b/test/clj_commons/pretty/annotations_test.clj
@@ -1,0 +1,117 @@
+(ns clj-commons.pretty.annotations-test
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [clj-commons.ansi :as ansi]
+            [clj-commons.test-common :as tc]
+            [clj-commons.pretty.annotations :refer [callouts default-style]]
+            [matcher-combinators.matchers :as m]))
+
+(use-fixtures :once tc/spec-fixture)
+
+(defn- compose-each
+  [coll]
+  (mapv ansi/compose coll))
+
+(defn compose-all
+  [& strings]
+  (compose-each strings))
+
+(deftest with-default-style
+  ;; Ultimately, comparing the strings with ANSI characters (the result of compose).
+  (is (match? (m/via compose-each
+                     (compose-all
+                       [:yellow "   ▲  ▲"]
+                       [:yellow "   │  │"]
+                       [:yellow "   │  └╴ Second"]
+                       [:yellow "   │"]
+                       [:yellow "   └╴ First"]))
+              (callouts [{:offset  3
+                          :message "First"}
+                         {:offset  6
+                          :message "Second"}]))))
+
+(deftest sorts-by-offset
+  (is (match? (m/via compose-each
+                     (compose-all
+                       [:yellow "   ▲  ▲"]
+                       [:yellow "   │  │"]
+                       [:yellow "   │  └╴ First"]
+                       [:yellow "   │"]
+                       [:yellow "   └╴ Second"]))
+              (callouts [{:offset  6
+                          :message "First"}
+                         {:offset  3
+                          :message "Second"}]))))
+
+(deftest with-annotation-length
+  (is (match? (m/via compose-each
+                     (compose-all
+                       [:yellow "   ▲▲ ▲▲▲▲"]
+                       [:yellow "   │  │"]
+                       [:yellow "   │  └╴ First"]
+                       [:yellow "   │"]
+                       [:yellow "   └╴ Second"]))
+              (callouts [{:offset  6
+                          :length  4
+                          :message "First"}
+                         {:offset  3
+                          :length  2
+                          :message "Second"}]))))
+
+(deftest with-annotation-font
+  (is (match? (m/via compose-each
+                     (compose-all
+                       [:yellow "   ▲▲ " [:red "▲▲▲▲"]]
+                       [:yellow "   │  " [:red "│"]]
+                       [:yellow "   │  " [:red "└╴ First"]]
+                       [:yellow "   │"]
+                       [:yellow "   └╴ Second"]))
+              (callouts [{:offset  6
+                          :length  4
+                          :font    :red
+                          :message "First"}
+                         {:offset  3
+                          :length  2
+                          :message "Second"}]))))
+
+(deftest spacing-minimal
+  (is (match? (m/via compose-each
+                     (compose-all
+                       [:yellow "   ▲  ▲"]
+                       [:yellow "   │  └╴ Second"]
+                       [:yellow "   └╴ First"]))
+              (callouts (assoc default-style :spacing :minimal)
+                        [{:offset  3
+                          :message "First"}
+                         {:offset  6
+                          :message "Second"}]))))
+
+(deftest spacing-compact
+  (is (match? (m/via compose-each
+                     (compose-all
+                       [:yellow "   ▲  ▲"]
+                       [:yellow "   │  │"]
+                       [:yellow "   │  └╴ Second"]
+                       [:yellow "   └╴ First"]))
+              (callouts (assoc default-style :spacing :compact)
+                        [{:offset  3
+                          :message "First"}
+                         {:offset  6
+                          :message "Second"}]))))
+
+(deftest custom-style
+  (is (match? (m/via compose-each
+                     (compose-all
+                       [:blue "   ~  ~~"]
+                       [:blue "   !  !"]
+                       [:blue "   !  +> Second"]
+                       [:blue "   +> First"]))
+              (callouts {:font    :blue
+                         :marker  "~"
+                         :bar     "!"
+                         :nib     "+> "
+                         :spacing :compact}
+                        [{:offset  3
+                          :message "First"}
+                         {:offset  6
+                          :length 2
+                          :message "Second"}]))))

--- a/test/clj_commons/test_common.clj
+++ b/test/clj_commons/test_common.clj
@@ -1,0 +1,11 @@
+(ns clj-commons.test-common
+  (:require clj-commons.pretty.spec
+            [clojure.spec.test.alpha :as stest]))
+
+(defn spec-fixture
+  [f]
+  (try
+    (stest/instrument)
+    (f)
+    (finally
+      (stest/unstrument))))


### PR DESCRIPTION
These are utilities that could be associated with code that parses any kind of input and wants to produce well formatted output about errors in that code.

In addition, create a `spec` namespace that covers `clj-commons.ansi` and `clj-commons.pretty.annotations`.