### PR TITLE
Fix `normalize-and-pad-markup` to skip actually padding

### DIFF
--- a/src/clj_commons/ansi.clj
+++ b/src/clj_commons/ansi.clj
@@ -196,11 +196,11 @@
     ;; If at or over desired width, don't need to pad
     (if (<= width actual-width)
       {:width actual-width
-       :span inputs'})
-    ;; Add the padding in the desired position(s); this ensures that the logic that generates
-    ;; ANSI escape codes occurs correctly, with the added spaces getting the font for this span.
-    {:width width
-     :span (apply-padding inputs' pad width actual-width)}))
+       :span inputs'}
+      ;; Add the padding in the desired position(s); this ensures that the logic that generates
+      ;; ANSI escape codes occurs correctly, with the added spaces getting the font for this span.
+      {:width width
+       :span (apply-padding inputs' pad width actual-width)})))
 
 
 (defn- normalize-markup


### PR DESCRIPTION
I ended up reading through the ANSI namespace while tracking down a red herring, and stumbled on this `if` form. The call to `apply-padding` wasn't changing the data, but it would incur some amount of processing overhead that we don't need to do.

Thanks for considering, and let me know if there's anything I need to adjust/modify.